### PR TITLE
fix: Add deps.ts for no import config

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,9 +5,5 @@
     "$fresh/": "https://deno.land/x/fresh@1.5.2/",
     "preact": "https://esm.sh/preact@10.18.1",
     "preact/": "https://esm.sh/preact@10.18.1/",
-    "postcss/": "https://deno.land/x/postcss@8.4.16/",
-    "postcss-js": "https://esm.sh/postcss-js@4.0.1",
-    "autoprefixer": "https://esm.sh/autoprefixer",
-    "tailwindcss": "npm:tailwindcss@3.3.3"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,13 @@
 {
   "lock": false,
+  "tasks": {
+    "test": "deno test --allow-write --allow-read --allow-env --config=./deno.json"
+  },
   "imports": {
     "$std/": "https://deno.land/std@0.204.0/",
     "$fresh/": "https://deno.land/x/fresh@1.5.2/",
     "preact": "https://esm.sh/preact@10.18.1",
     "preact/": "https://esm.sh/preact@10.18.1/",
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.1",
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,12 @@
+import type {
+  AcceptedPlugin,
+  ProcessOptions,
+  Result,
+} from "https://deno.land/x/postcss@8.4.16/lib/postcss.js";
+import postcss from "https://deno.land/x/postcss@8.4.16/mod.js";
+export { default as autoprefixer } from "https://esm.sh/autoprefixer@10.4.16";
+export { default as tailwindcss } from "npm:tailwindcss@3.3.3";
+
+export type { AcceptedPlugin, ProcessOptions, Result };
+
+export { postcss };

--- a/mod.ts
+++ b/mod.ts
@@ -4,14 +4,8 @@ import type {
   PluginRenderResult,
 } from "$fresh/server.ts";
 import { asset } from "$fresh/runtime.ts";
-import type {
-  AcceptedPlugin,
-  ProcessOptions,
-  Result,
-} from "postcss/lib/postcss.js";
-import postcss from "postcss/mod.js";
-import autoprefixer from "autoprefixer";
-import tailwind from "tailwindcss";
+import type { AcceptedPlugin, ProcessOptions, Result } from "./deps.ts";
+import { autoprefixer, postcss, tailwindcss as tailwind } from "./deps.ts";
 import { getConfig } from "./_tailwind.ts";
 
 /**


### PR DESCRIPTION
Closes #4 
- Added `deps.ts` to allow devs to skip updating import maps