### PR TITLE
Using the latest version of toFileUrl

### DIFF
--- a/_tailwind.ts
+++ b/_tailwind.ts
@@ -1,4 +1,4 @@
-import { toFileUrl } from "$std/path/to_file_url.ts";
+import { toFileUrl } from "https://deno.land/std@0.204.0/path/to_file_url.ts";
 /**
  * Load Tailwind configuration from a file.
  * @param configFile __Absolute__ path to the Tailwind config file.


### PR DESCRIPTION
The function toFileUrl was added `path 0.198.0`, not specifying the version got me an error (I didn't really works because I'm not sure how to debug Deno modules, but on my tests it worked)