### PR TITLE
feat: Tailwind standalone CLI usage

### DIFF
--- a/_tailwind.ts
+++ b/_tailwind.ts
@@ -1,4 +1,29 @@
 import { toFileUrl } from "https://deno.land/std@0.204.0/path/to_file_url.ts";
+
+export async function tryImportConfig(
+  configFile?: string,
+) {
+  const scripts = [toFileUrl(`${Deno.cwd()}/tailwind.config.ts`).href];
+  scripts[1] = scripts[0].replace(/\.ts$/, ".js");
+  scripts[2] = scripts[0].replace(/\.ts$/, ".mjs");
+
+  for (const script of scripts) {
+    try {
+      const config = await import(
+        configFile ?? script
+      );
+
+      return config.default;
+    } catch (err) {
+      if (
+        !(err instanceof Deno.errors.NotFound) && !(err instanceof TypeError)
+      ) {
+        throw err;
+      }
+    }
+  }
+}
+
 /**
  * Load Tailwind configuration from a file.
  * @param configFile __Absolute__ path to the Tailwind config file.
@@ -12,15 +37,14 @@ export async function getConfig(
       "./routes/**/*.{tsx,jsx,ts,js}",
       "./islands/**/*.{tsx,jsx,ts,js}",
       "./components/**/*.{tsx,jsx,ts,js",
+      "./src/**/*.css",
     ],
     theme: { extend: {} },
     plugins: [],
   };
 
   try {
-    const config = (await import(
-      configFile ?? toFileUrl(`${Deno.cwd()}/tailwind.config.ts`).href
-    )).default;
+    const config = await tryImportConfig(configFile);
 
     return {
       ...defaultConfig,

--- a/_tailwind.ts
+++ b/_tailwind.ts
@@ -1,5 +1,16 @@
-import { join, toFileUrl } from "./deps.ts";
+import { toFileUrl } from "./deps.ts";
 
+/**
+ * Attempt to import a Tailwind configuration file.
+ * If no file is provided, it will attempt to import the default config file names.
+ * @param configFile Optional file path to the Tailwind config file.
+ * @returns Imported configuration file
+ * @throws {Error} If the config file is not found
+ * @example
+ * ```ts
+ * const config = await tryImportConfig("./tailwind.config.ts");
+ * ```
+ */
 export async function tryImportConfig(
   configFile?: string,
 ) {
@@ -25,9 +36,15 @@ export async function tryImportConfig(
 }
 
 /**
- * Load Tailwind configuration from a file.
+ * Load Tailwind configuration from a file. Return a default configuration if no file is provided.
  * @param configFile __Absolute__ path to the Tailwind config file.
  * @returns Tailwind configuration
+ * @throws {Error} If the config file is not found
+ * @example
+ * ```ts
+ * const config = await getConfig("./tailwind.config.ts");
+ * ```
+ * @uses {@link tryImportConfig}
  */
 export async function getConfig(
   configFile?: string,

--- a/_tailwind.ts
+++ b/_tailwind.ts
@@ -1,4 +1,4 @@
-import { toFileUrl } from "https://deno.land/std@0.204.0/path/to_file_url.ts";
+import { join, toFileUrl } from "./deps.ts";
 
 export async function tryImportConfig(
   configFile?: string,

--- a/build.ts
+++ b/build.ts
@@ -13,7 +13,7 @@ export interface TailwindPluginOptions {
 export default function tailwindBuildPlugin(options?: TailwindPluginOptions) {
   const fileName = options?.dest ?? "style.css";
   const plugin: Plugin = {
-    name: "tailwind_plugin",
+    name: "tailwind_build_plugin",
     buildStart: async (config) => {
       const tailwindBin =
         JSON.parse(await Deno.readTextFile(join(Deno.cwd(), "deno.json")))
@@ -23,7 +23,7 @@ export default function tailwindBuildPlugin(options?: TailwindPluginOptions) {
       const tailwindCmd = new Deno.Command(tailwindBin, {
         args: [
           "-o",
-          `${config?.build?.outDir ?? config.staticDir}/${fileName}`,
+          `${config.staticDir}/${fileName}`,
           "--config",
           `${Deno.cwd()}/tailwind.config.ts`,
           !config.dev ? "--minify" : "",

--- a/build.ts
+++ b/build.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "$fresh/server.ts";
-import { join } from "$std/path/mod.ts";
+import { join } from "./deps.ts";
 
 export interface TailwindPluginOptions {
   dest?: string;

--- a/build.ts
+++ b/build.ts
@@ -1,0 +1,38 @@
+import type { Plugin } from "$fresh/server.ts";
+import { join } from "$std/path/mod.ts";
+
+export interface TailwindPluginOptions {
+  dest?: string;
+}
+
+/**
+ * Fresh plugin which processes Tailwind CSS.
+ * @param options - {@link TailwindOptions}
+ * @returns Fresh Tailwind plugin
+ */
+export default function tailwindBuildPlugin(options?: TailwindPluginOptions) {
+  const fileName = options?.dest ?? "style.css";
+  const plugin: Plugin = {
+    name: "tailwind_plugin",
+    buildStart: async (config) => {
+      const tailwindBin =
+        JSON.parse(await Deno.readTextFile(join(Deno.cwd(), "deno.json")))
+          ?.tasks
+          ?.tailwind ?? "./bin/tailwindcss";
+
+      const tailwindCmd = new Deno.Command(tailwindBin, {
+        args: [
+          "-o",
+          `${config?.build?.outDir ?? config.staticDir}/${fileName}`,
+          "--config",
+          `${Deno.cwd()}/tailwind.config.ts`,
+          !config.dev ? "--minify" : "",
+        ],
+      });
+
+      await tailwindCmd.output();
+    },
+  };
+
+  return plugin;
+}

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,275 @@
+#!/usr/bin/env -S deno run --allow-sys=osRelease --allow-net=github.com,objects.githubusercontent.com --allow-read=./ --allow-write=./
+import { ensureDir, join } from "./deps.ts";
+
+// Download standalone Tailwind CLI from GitHub releases.
+// Get the users OS and architecture.
+// Attempt to download the appropriate binary.
+// Compare it to the checksums.
+
+const TAILWIND_VERSION = "3.3.3";
+const TAILWIND_REPO =
+  `https://github.com/tailwindlabs/tailwindcss/releases/download/v${TAILWIND_VERSION}`;
+
+/**
+ * Attempt to download the Tailwind CLI binary from GitHub releases for the current OS and architecture.
+ * Requires several permsissions:
+ * - read access to the working directory
+ * - write access to the working directory
+ * - network access to GitHub and GitHub user content
+ * - System OS information
+ * @param root Project root directory. Defaults to the current working directory.
+ * @returns Path to Tailwind CLI executable
+ * @throws {Error} If the checksums do not match
+ */
+async function download(root?: string, dest = "./bin"): Promise<string> {
+  if (!root) {
+    console.info(
+      "A root directory has not been defined. Attempting to use the current working directory.",
+    );
+  }
+
+  const allowRead = await Deno.permissions.query({
+    name: "read",
+    path: root ?? "./",
+  });
+
+  if (allowRead.state !== "granted") {
+    console.log(
+      `Please allow read access to ${
+        root ?? "the current working directory"
+      } to download Tailwind CSS files.`,
+    );
+  }
+
+  const requestRead = await Deno.permissions.request({
+    name: "read",
+    path: root ?? "./",
+  });
+
+  if (requestRead.state !== "granted") {
+    throw new Error(
+      `Please allow read access to ${
+        root ?? "the current working directory"
+      } to download Tailwind CSS files.`,
+    );
+  }
+
+  const cwd = root ?? Deno.cwd();
+  const checksums: Record<string, string> = {};
+
+  const allowNet = await Deno.permissions.query({
+    name: "net",
+    host: "github.com",
+  });
+
+  if (allowNet.state !== "granted") {
+    console.log(
+      `Please allow network access to GitHub (and asset download redirects) to download Tailwind CSS files from the following URL: ${TAILWIND_REPO}`,
+    );
+  }
+
+  const requestNet = await Deno.permissions.request({
+    name: "net",
+    host: "github.com",
+  });
+
+  const requestNetContent = await Deno.permissions.request({
+    name: "net",
+    host: "objects.githubusercontent.com",
+  });
+
+  if (requestNet.state !== "granted" || requestNetContent.state !== "granted") {
+    throw new Error(
+      "Please allow network access to GitHub and GitHub user content to download Tailwind CSS files.",
+    );
+  }
+
+  console.log(`Fetching Tailwind CSS v${TAILWIND_VERSION} checksums...`);
+  const res = await fetch(`${TAILWIND_REPO}/sha256sums.txt`);
+
+  // Convert the result to the checksums object.
+  // Then convert the Deno OS and architecture to the appropriate binary name and checksum.
+  // Finally, compare the checksums.
+
+  const text = await res.text();
+  const lines = text.split("\n").filter((line) => line.trim() !== "");
+  for (const line of lines) {
+    const [checksum, filename] = line.split(/\s+/);
+    checksums[filename.replace(".exe", "")] = checksum;
+  }
+
+  // Deno OS and architecture names are different than the ones used by Tailwind.
+  // Convert them to Tailwind's names.
+
+  const osMap: Record<string, string> = {
+    darwin: "macos",
+    linux: "linux",
+    windows: "windows",
+  };
+  const archMap: Record<string, string> = {
+    x64: "x64",
+    arm64: "arm64",
+    arm: "armv7",
+  };
+  const tailwindOs = osMap[Deno.build.os];
+  const tailwindArch = archMap[Deno.build.arch] ?? "x64";
+
+  // Get the checksum for the current OS and architecture.
+  // If it doesn't exist, throw an error.
+
+  const checksum = checksums[`tailwindcss-${tailwindOs}-${tailwindArch}`];
+  if (!checksum) {
+    throw new Error(`Checksum not found for ${tailwindOs}-${tailwindArch}`);
+  }
+
+  const exeExtension = Deno.build.os === "windows" ? ".exe" : "";
+
+  // Download the binary from GitHub releases.
+  // Compare the checksums.
+  // If they don't match, throw an error.
+
+  console.log(
+    `Downloading Tailwind CSS v${TAILWIND_VERSION} for ${Deno.build.os}-${Deno.build.arch}...`,
+  );
+  const dl = await fetch(
+    `${TAILWIND_REPO}/tailwindcss-${tailwindOs}-${tailwindArch}${exeExtension}`,
+  );
+  const data = await dl.arrayBuffer();
+  // Compare binary download to checksum before writing to disk
+
+  const actualChecksum = await crypto.subtle.digest("SHA-256", data);
+
+  // Compare array buffer checksum to string checksum
+  if (
+    checksum !== [...new Uint8Array(actualChecksum)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+  ) {
+    throw new Error("Checksums do not match!");
+  }
+
+  const binDest = join(cwd, dest);
+  const allowWrite = await Deno.permissions.query({ name: "write", path: cwd });
+
+  if (allowWrite.state !== "granted") {
+    console.log(
+      `Please allow write access to ${cwd} to download Tailwind CSS files.`,
+    );
+  }
+
+  const requestWrite = await Deno.permissions.request({
+    name: "write",
+    path: cwd,
+  });
+
+  if (requestWrite.state !== "granted") {
+    throw new Error(
+      `Please allow write access to ${cwd} to download Tailwind CSS files.\n\nYou can also download the Tailwind CSS binary manually from ${TAILWIND_REPO} and place it in ${binDest}`,
+    );
+  }
+
+  // Write the binary to disk.
+  // Make it executable.
+  // Add it to the current working directory's "bin" directory.
+  // Make the bin directory if it doesn't exist.
+  await ensureDir(binDest);
+
+  const executable = join(binDest, `tailwindcss${exeExtension}`);
+
+  await Deno.writeFile(
+    executable,
+    new Uint8Array(data),
+  );
+
+  console.log(
+    `Successfully downloaded %cTailwind CLI %c v${TAILWIND_VERSION} %c for %c${tailwindOs}-${tailwindArch}`,
+    "color: cyan;",
+    "background-color:cyan;color:black;",
+    "",
+    "color: yellow; padding: 0.1em;",
+  );
+
+  return executable;
+}
+
+/**
+ * Add Tailwind CLI commands to Deno tasks.
+ * @param cwd - Current working directory for Deno project.
+ */
+export async function addTask(cwd?: string) {
+  // Add task to deno.json
+  const denoJsonPath = join(cwd ?? "./", "deno.json");
+  try {
+    const denoJson = JSON.parse(await Deno.readTextFile(denoJsonPath));
+    denoJson.tasks = denoJson.tasks ?? {};
+
+    denoJson.tasks.tailwind = "./bin/tailwindcss";
+
+    await Deno.writeTextFile(denoJsonPath, JSON.stringify(denoJson, null, 2));
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      throw new Error(
+        "Could not find deno.json in the specified working directory.",
+      );
+    }
+
+    throw err;
+  }
+
+  console.log(
+    "Tailwind CLI commands have been added to your Deno tasks. Run %cdeno task tailwind%c... for Tailwind CLI commands.",
+    "color:teal;",
+    "",
+  );
+}
+
+export default async function init(root?: string, updateTasks = true) {
+  const executable = await download(root);
+
+  if (updateTasks) {
+    await addTask(root);
+  }
+  return executable;
+}
+
+if (import.meta.main) {
+  try {
+    // Read is required for execPath
+    const allowRead = await Deno.permissions.query({
+      name: "read",
+    });
+
+    if (allowRead.state !== "granted") {
+      console.warn(
+        "Please allow read access to the current working directory to run Tailwind CSS.",
+      );
+    }
+
+    const cmd = new Deno.Command(Deno.execPath(), {
+      args: [
+        "task",
+        "tailwind",
+        ...Deno.args.slice(1),
+      ],
+    });
+
+    const { stdout } = await cmd.output();
+
+    const decoder = new TextDecoder();
+    const text = decoder.decode(stdout);
+
+    console.log(text);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound) && !(err instanceof TypeError)) {
+      console.error(err);
+      await init(Deno.args[0] ?? Deno.cwd(), Deno.args[1] !== "--no-tasks");
+      console.log(
+        "Run %cdeno task tailwind%c... for Tailwind CLI commands.",
+        "color:teal;",
+        "",
+      );
+    }
+
+    throw err;
+  }
+}

--- a/deps.ts
+++ b/deps.ts
@@ -5,8 +5,11 @@ import type {
 } from "https://deno.land/x/postcss@8.4.16/lib/postcss.js";
 import postcss from "https://deno.land/x/postcss@8.4.16/mod.js";
 export { default as autoprefixer } from "https://esm.sh/autoprefixer@10.4.16";
-export { default as tailwindcss } from "npm:tailwindcss@3.3.3";
+export { type Config, default as tailwindcss } from "npm:tailwindcss@3.3.3";
 
 export type { AcceptedPlugin, ProcessOptions, Result };
 
 export { postcss };
+
+export { basename, join } from "$std/path/mod.ts";
+export { ensureDir } from "$std/fs/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -10,6 +10,6 @@ export { type Config, default as tailwindcss } from "npm:tailwindcss@3.3.3";
 export type { AcceptedPlugin, ProcessOptions, Result };
 
 export { postcss };
-
-export { basename, join } from "$std/path/mod.ts";
-export { ensureDir } from "$std/fs/mod.ts";
+export { toFileUrl } from "https://deno.land/std@0.204.0/path/to_file_url.ts";
+export { basename, join } from "https://deno.land/std@0.204.0/path/mod.ts";
+export { ensureDir } from "https://deno.land/std@0.204.0/fs/mod.ts";

--- a/main.ts
+++ b/main.ts
@@ -9,5 +9,5 @@ const tailwind = tailwindPlugin({
 });
 
 if (import.meta.main) {
-  await tailwind.buildStart!();
+  await tailwind.build();
 }

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,26 @@
 import tailwindPlugin from "./mod.ts";
-import { join } from "$std/path/mod.ts";
+/**
+ * @example Run Tailwind installation from command line.
+ * ```
+ * deno run -A https://deno.land/x/fresh_tailwind/main.ts --install
+ * ```
+ *
+ * @example Run Tailwind build from command line.
+ * ```
+ * deno run -A https://deno.land/x/fresh_tailwind/main.ts
+ * ```
+ */
+async function run() {
+  const tailwind = tailwindPlugin();
 
-const css = await Deno.readTextFile(join(Deno.cwd(), "src", "style.css"));
+  if (Deno.args.includes("--install")) {
+    await tailwind.install();
+    return;
+  }
 
-const tailwind = tailwindPlugin({
-  css,
-  dest: "./static/styles.css",
-});
+  await tailwind.build();
+}
 
 if (import.meta.main) {
-  await tailwind.build();
+  await run();
 }

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -4,14 +4,10 @@ import {
   assertStringIncludes,
 } from "$std/assert/mod.ts";
 import tailwindPlugin, { STYLE_ELEMENT_ID } from "./mod.ts";
+import type { ResolvedFreshConfig } from "$fresh/src/server/types.ts";
 
 Deno.test("Test PostCSS/Tailwind with render hook", async function processTailwindTest() {
-  const plugin = tailwindPlugin({
-    css: `.test {
-      @apply text-red-500;
-    }`,
-    hookRender: true,
-  });
+  const plugin = tailwindPlugin();
 
   assertNotEquals(plugin, undefined);
 
@@ -45,15 +41,7 @@ Deno.test("Test PostCSS/Tailwind with render hook", async function processTailwi
 });
 
 Deno.test("Test PostCSS/Tailwind with build step", async function buildTailwindTest() {
-  const plugin = tailwindPlugin({
-    css: `.test {
-      @apply text-green-500;
-    }`,
-    hookRender: false,
-    staticDir: "./test",
-    dest: "./test/style.css",
-    configFile: "./test/tailwind.config.ts",
-  });
+  const plugin = tailwindPlugin();
 
   assertNotEquals(plugin, undefined);
 
@@ -61,7 +49,14 @@ Deno.test("Test PostCSS/Tailwind with build step", async function buildTailwindT
     throw new Error("Plugin is undefined");
   }
 
-  await plugin.buildStart?.();
+  await plugin.buildStart!(
+    {
+      build: {
+        outDir: "./test",
+        target: ["esnext"],
+      },
+    } as ResolvedFreshConfig,
+  );
 
   const css = await Deno.readTextFile("./test/style.css");
 

--- a/mod.ts
+++ b/mod.ts
@@ -9,6 +9,7 @@ import { autoprefixer, postcss, tailwindcss as tailwind } from "./deps.ts";
 import { getConfig } from "./_tailwind.ts";
 import init from "./cli.ts";
 import { ResolvedFreshConfig } from "$fresh/src/server/types.ts";
+import { ensureDir } from "$std/fs/ensure_dir.ts";
 
 /**
  * Fresh Tailwind plugin settings.
@@ -165,6 +166,7 @@ export default function tailwindPlugin(
       ...opts,
     });
     const dest = opts?.dest ?? "./static/style.css";
+    await ensureDir(dest.split("/").slice(0, -1).join("/"));
     await Deno.writeTextFile(dest, css);
   };
 

--- a/mod.ts
+++ b/mod.ts
@@ -3,12 +3,17 @@ import type {
   PluginRenderResult,
 } from "$fresh/server.ts";
 import { asset, IS_BROWSER } from "$fresh/runtime.ts";
-import type { AcceptedPlugin, Result } from "./deps.ts";
-import { autoprefixer, postcss, tailwindcss as tailwind } from "./deps.ts";
+import {
+  type AcceptedPlugin,
+  autoprefixer,
+  ensureDir,
+  postcss,
+  type Result,
+  tailwindcss as tailwind,
+} from "./deps.ts";
 import { getConfig } from "./_tailwind.ts";
 import init from "./cli.ts";
 import { ResolvedFreshConfig } from "$fresh/src/server/types.ts";
-import { ensureDir } from "$std/fs/ensure_dir.ts";
 import type { TailwindOptions, TailwindPlugin } from "./types.ts";
 
 /**
@@ -97,7 +102,7 @@ async function renderTailwind(
     }
   } catch (err) {
     console.warn("Failed to write Tailwind CSS to file.\n%s", err);
-    // Fallback to injecting styles into HTML
+    // Fallback to including styles in HTML
     styles[0].cssText = css;
   }
 

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,50 @@
+import type { Plugin } from "$fresh/server.ts";
+import type { AcceptedPlugin, ProcessOptions } from "./deps.ts";
+
+export interface TailwindPlugin extends Plugin {
+  install: () => Promise<Plugin>;
+  build: () => Promise<void>;
+}
+
+/**
+ * Fresh Tailwind plugin settings.
+ */
+export interface TailwindOptions {
+  css?: string;
+  /**
+   * List of PostCSS plugins to use.
+   * (Already includes Tailwind and Autoprefixer.)
+   */
+  plugins?: AcceptedPlugin[];
+  /**
+   * Options to pass onto PostCSS.
+   * Include `from` and `to` options to enable source maps.
+   */
+  postcssOptions?: ProcessOptions;
+  /**
+   * List of paths to files that should be scanned for classes.
+   * Defaults to check routes, islands and components.
+   */
+  tailwindContent?: Array<string | { raw: string; extension: string }>;
+  // TODO: Get from Fresh
+  /**
+   * The destination of the generated CSS file.
+   * Should include file name. Defaults to `./static/style.css`.
+   */
+  dest?: string;
+  /**
+   * The Fresh static content directory path.
+   * Defaults to `./static`.
+   */
+  staticDir?: string;
+  /**
+   * Whether to hook into the render process.
+   * Useful during development.
+   */
+  hookRender?: boolean;
+
+  /**
+   * The Tailwind configuration file path.
+   */
+  configFile?: string;
+}


### PR DESCRIPTION
- Added features to download Tailwind standalone binary from GitHub for usage with Deno command processes
- Created secondary `tailwindBuildPlugin` for using the binary to compile Tailwind CSS