### PR TITLE
fix: Do not require deno.json for CLI build

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -3,6 +3,7 @@ import { join } from "./deps.ts";
 
 export interface TailwindPluginOptions {
   dest?: string;
+  binLocation?: string;
 }
 
 /**
@@ -15,10 +16,7 @@ export default function tailwindBuildPlugin(options?: TailwindPluginOptions) {
   const plugin: Plugin = {
     name: "tailwind_build_plugin",
     buildStart: async (config) => {
-      const tailwindBin =
-        JSON.parse(await Deno.readTextFile(join(Deno.cwd(), "deno.json")))
-          ?.tasks
-          ?.tailwind ?? "./bin/tailwindcss";
+      const tailwindBin = options?.binLocation ?? "./bin/tailwindcss";
 
       const tailwindCmd = new Deno.Command(tailwindBin, {
         args: [


### PR DESCRIPTION
- Allow devs to pass a Tailwind CLI location if it needs to change, rather than finding the Deno task